### PR TITLE
add a prompt when listing all files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use getopts::Options;
 use regex::Regex;
 use std::env;
 use std::path::PathBuf;
+use std::io;
 use walkdir::{WalkDir, WalkDirIterator};
 
 fn print_usage(opts: Options) {
@@ -38,6 +39,17 @@ fn main() {
         return;
     }
 
+
+    if matches.free.get(0) == None{
+        println!("You are about to list every single file in this directory and its subdirectories.\nWas that your intention?\ny/n");
+        let mut input = String::new();
+
+        match io::stdin().read_line(&mut input) {
+            Ok(_) if input == "y\n" => (),
+            _ => return
+        }
+    }
+
     let mut search = match matches.free.get(0) {
         Some(x) => x.clone(),
         _ => String::from("")
@@ -56,6 +68,7 @@ fn main() {
         Some(d) => PathBuf::from(d),
         _ => env::current_dir().unwrap()
     };
+
 
     let mut walker = WalkDir::new(&dir).into_iter();
 


### PR DESCRIPTION
In order to prevent annoying (& most likely erroneous) behaviour, I've added
a check when no arguments are passed. This gives the user a chance
to cancel the search before it starts looking for every file in all
subdirectories.
